### PR TITLE
On tag tous les jours notre build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
   schedule:
-    - cron: '0 19 1 * *'
+    - cron: '0 8 * * *'
 
 jobs:
   latest:


### PR DESCRIPTION
Permet d'avoir des tags autant très récent que très ancien.
L'ancien cron n'est pas adapté à un projet en mouvement perpétuel. Depuis la création des tags, on maitrise beaucoup plus ce qui est déployé