### PR TITLE
Suppression de rar et correction filemanager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,17 +21,7 @@ RUN apk add --no-progress \
     linux-headers \
     openjdk8 \
     openjdk8-jre \
-    zlib-dev \
-  # Install RAR
-  && case "${TARGETPLATFORM}" in \
-    "linux/amd64") wget -O rarlinux.tar.gz https://www.rarlab.com/rar/rarlinux-x64-6.0.2.tar.gz;; \
-    "linux/arm64") wget -O rarlinux.tar.gz https://www.rarlab.com/rar/rarlinux-6.0.2.tar.gz;; \
-  esac \
-  && tar -xzvf rarlinux.tar.gz \
-  && mv rar/rar /usr/bin \
-  && chmod 755 /usr/bin/rar \
-  && rm -rf rar \
-  && rm rarlinux.tar.gz \  
+    zlib-dev \  
   # Downloads projects
   && git clone https://github.com/borisbrodski/sevenzipjbinding.git /tmp/SevenZipJBinding \
   # Set BUILD_CORES

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apk add --no-progress \
     linux-headers \
     openjdk8 \
     openjdk8-jre \
-    zlib-dev \  
+    zlib-dev \
   # Downloads projects
   && git clone https://github.com/borisbrodski/sevenzipjbinding.git /tmp/SevenZipJBinding \
   # Set BUILD_CORES

--- a/rootfs/rutorrent/app/plugins/filemanager/conf.php
+++ b/rootfs/rutorrent/app/plugins/filemanager/conf.php
@@ -2,26 +2,24 @@
 
 global $pathToExternals;
 // set with fullpath to binary or leave empty
+// $pathToExternals['rar'] = ''; # Not compatible with alpine image
 $pathToExternals['zip'] = '/usr/bin/zip';
 $pathToExternals['unzip'] = '/usr/bin/unzip';
 $pathToExternals['tar'] = '/bin/tar';
 $pathToExternals['gzip'] = '/bin/gzip';
-$pathToExternals['rar'] = '/usr/bin/rar';
 $pathToExternals['bzip2'] = '/usr/bin/bzip2';
 
-
-$config['mkdperm'] = 755; 		// default permission to set to new created directories
-$config['tempdir'] = '/tmp';
+$config['mkdperm'] = 755; // default permission to set to new created directories
 $config['show_fullpaths'] = false; // wheter to show userpaths or full system paths in the UI
 
+$config['textExtensions'] = 'log|txt|nfo|sfv|xml|html';
 
-$config['textExtensions'] = 'txt|nfo|sfv|xml|html';
 // archive mangling, see archiver man page before editing
 // archive.fileExt -> config
 $config['archive']['type'] = [
-    'rar' => [  'bin' =>'rar',
-                'compression' => range(0, 5),
-    ],
+    // 'rar' => [  'bin' =>'rar',
+    //             'compression' => range(0, 5),
+    // ],
     'zip' => [
         'bin' =>'zip',
         'compression' => ['-0', '-1', '-9'],


### PR DESCRIPTION
Rar n'est pas installable sur alpine ou du moins pas d'une manière simple..
Après plusieurs tentatives, même dans /usr/local/bin, le fichier est introuvable (et je suis en root) alors qu'il a bien été déplacé et bien visible dans le build.
Vu qu'il ne fonctionne pas depuis X années, autant le supprimer..

Correction de la conf du filemanager #40 

Résultat : Plus d'erreur rar.