### PR TITLE
Fix $profilePath variable

### DIFF
--- a/rootfs/rutorrent/app/conf/config.php
+++ b/rootfs/rutorrent/app/conf/config.php
@@ -38,7 +38,7 @@ $pathToExternals = [
     'pgrep' => '/usr/bin/pgrep'
 ];
 $localhosts = ['127.0.0.1', 'localhost'];
-$profilePath = '../share'; // Path to user profiles
+$profilePath = '../../share'; // Path to user profiles
 $profileMask = 0777;
 $tempDirectory = null; // Temp directory. Absolute path with trail slash. If null, then autodetect will be used.
 $canUseXSendFile = false; // If true then use X-Sendfile feature if it exist


### PR DESCRIPTION
The `$profilePath` variable was changed in ruTorrent. `fileutil.php` which references it is located in the `php/utility` folder now. So it must go back 2 directories instead of 1 now to reach the share folder. https://github.com/Novik/ruTorrent/blob/master/conf/config.php#L62

See this issue for more details. https://github.com/Novik/ruTorrent/issues/2280