### PR TITLE
cURL: Build with c-ares for rTorrent

### DIFF
--- a/rootfs/rutorrent/app/conf/config.php
+++ b/rootfs/rutorrent/app/conf/config.php
@@ -54,7 +54,7 @@
 
 	$pathToExternals = array(
 		"php"	=> '/usr/bin/php82',				// Something like /usr/bin/php. If empty, will be found in PATH.
-		"curl"	=> '/usr/bin/curl',					// Something like /usr/bin/curl. If empty, will be found in PATH.
+		"curl"	=> '/usr/local/bin/curl',			// Something like /usr/bin/curl. If empty, will be found in PATH.
 		"gzip"	=> '/usr/bin/gzip',					// Something like /usr/bin/gzip. If empty, will be found in PATH.
 		"id"	=> '/usr/bin/id',					// Something like /usr/bin/id. If empty, will be found in PATH.
 		"stat"	=> '/usr/bin/stat',					// Something like /usr/bin/stat. If empty, will be found in PATH.


### PR DESCRIPTION
This PR builds curl with c-ares for asynchronous DNS resolution of TCP trackers on rTorrent. I've also updated ruTorrent with the new path of curl. This prevents rTorrent from freezing with a large number of torrents with TCP trackers. See here for more information: https://github.com/rakshasa/rtorrent/wiki/Performance-Tuning#name-resolving-enhancements