### PR TITLE
cURL: Fix external program not found

### DIFF
--- a/rootfs/rutorrent/app/conf/config.php
+++ b/rootfs/rutorrent/app/conf/config.php
@@ -54,7 +54,7 @@
 
 	$pathToExternals = array(
 		"php"	=> '/usr/bin/php82',				// Something like /usr/bin/php. If empty, will be found in PATH.
-		"curl"	=> '/usr/local/bin/curl',			// Something like /usr/bin/curl. If empty, will be found in PATH.
+		"curl"	=> '',			                    // Something like /usr/bin/curl. If empty, will be found in PATH.
 		"gzip"	=> '/usr/bin/gzip',					// Something like /usr/bin/gzip. If empty, will be found in PATH.
 		"id"	=> '/usr/bin/id',					// Something like /usr/bin/id. If empty, will be found in PATH.
 		"stat"	=> '/usr/bin/stat',					// Something like /usr/bin/stat. If empty, will be found in PATH.


### PR DESCRIPTION
Removing the hard-coded path will execute `command -v` from ruTorrent to find the curl application.

@Rathorian Please let me know if this resolves your cURL errors. 