### PR TITLE
cURL: Apply sed fix to update ruTorrent config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -161,6 +161,7 @@ RUN apk --update --no-cache add \
   && rm -rf /rutorrent/app/plugins/geoip2/.git \
   && rm -rf /rutorrent/app/plugins/ratiocolor/.git \
   && rm -rf /rutorrent/app/.git \
+  && sed -i -e "s/\/usr\/bin\/curl/\/usr\/local\/bin\/curl/g" /rutorrent/app/conf/conf.php
   # Socket folder
   && mkdir -p /run/rtorrent /run/nginx /run/php
 


### PR DESCRIPTION
This commit replaces curl in the ruTorrent config with the new location of the curl binary. 

It should fix these errors:
```
[10.12.2024 19:07:24] rss: Certaines fonctionnalités ne seront pas disponibles. Le serveur web ne peut pas accéder au(x) programme(s) externe(s). (curl).
[10.12.2024 19:07:24] rss: Certaines fonctionnalités ne seront pas disponibles. rTorrent ne peut pas accéder au(x) programme(s) externe(s). (curl).
```

The reason for the errors is the ruTorrent `config.php` file does not update when new docker image to deployed.