### PR TITLE
cURL: Apply sed fix to update ruTorrent config

### DIFF
--- a/rootfs/usr/local/bin/update-config
+++ b/rootfs/usr/local/bin/update-config
@@ -8,3 +8,6 @@ sed -e "s|'\/RPC'|'\/RPC2'|g" -i /config/rutorrent/conf/config.php
 
 # update to php82
 sed -e "s|'\/usr\/bin\/php81'|'\/usr\/bin\/php82'|g" -i /config/rutorrent/conf/config.php
+
+# replace new location of curl
+sed -i -e "s/\/usr\/bin\/curl/\/usr\/local\/bin\/curl/g" /config/rutorrent/conf/config.php


### PR DESCRIPTION
This commit replaces curl in the ruTorrent config with the new location of the curl binary. 

It should fix these errors:
```
[10.12.2024 19:07:24] rss: Certaines fonctionnalités ne seront pas disponibles. Le serveur web ne peut pas accéder au(x) programme(s) externe(s). (curl).
[10.12.2024 19:07:24] rss: Certaines fonctionnalités ne seront pas disponibles. rTorrent ne peut pas accéder au(x) programme(s) externe(s). (curl).
```

The reason for the errors is the ruTorrent `config.php` file does not update when new docker image to deployed.