### PR TITLE
ruTorrent: Upgrade to v5.2.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,7 +95,7 @@ LABEL description="rutorrent based on alpinelinux" \
 
 ARG FILEBOT=false
 ARG FILEBOT_VER=5.1.7
-ARG RUTORRENT_VER=5.2.4
+ARG RUTORRENT_VER=5.2.5
 
 ENV UID=991 \
     GID=991 \


### PR DESCRIPTION
**Full Changelog**: https://github.com/Novik/ruTorrent/compare/v5.2.4...v5.2.5

# ruTorrent v5.2.5
This is a critical hotfix. It's highly recommended to upgrade. It fixes applying labels to new torrents. The error behavior is also reverted based on community feedback.

## What's Changed
* Restore the original behavior of "Error" state based on community feedback by gashtal in https://github.com/Novik/ruTorrent/pull/2923
* fix for labeling new torrents by ranirahn in https://github.com/Novik/ruTorrent/pull/2925