### PR TITLE
ruTorrent: Upgrade to v5.2.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,7 +95,7 @@ LABEL description="rutorrent based on alpinelinux" \
 
 ARG FILEBOT=false
 ARG FILEBOT_VER=5.1.7
-ARG RUTORRENT_VER=5.2.5
+ARG RUTORRENT_VER=5.2.6
 
 ENV UID=991 \
     GID=991 \


### PR DESCRIPTION
# ruTorrent v5.2.6
This is an important hotfix. It's recommended to upgrade. 
1. It resolves a couple annoying bugs and glitches with the torrent status icons. (Thanks ranirahn) 
2. It adds full Brazilian Portuguese translations to ruTorrent. (Thanks cantalupo555)

## What's Changed
* l10n: Improve Brazilian Portuguese translations by cantalupo555 in https://github.com/Novik/ruTorrent/pull/2934
* fix for icons not getting added to torrent by ranirahn in https://github.com/Novik/ruTorrent/pull/2932
* fix for status icons added to wrong column by ranirahn in https://github.com/Novik/ruTorrent/pull/2936
* feat(i18n): Add pt-BR translations for multiple plugins by cantalupo555 in https://github.com/Novik/ruTorrent/pull/2938

## New Contributors
* cantalupo555 made their first contribution in https://github.com/Novik/ruTorrent/pull/2934

**Full Changelog**: https://github.com/Novik/ruTorrent/compare/v5.2.5...v5.2.6