### PR TITLE
ruTorrent: Upgrade to v5.2.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,7 +95,7 @@ LABEL description="rutorrent based on alpinelinux" \
 
 ARG FILEBOT=false
 ARG FILEBOT_VER=5.1.7
-ARG RUTORRENT_VER=5.2.6
+ARG RUTORRENT_VER=5.2.8
 
 ENV UID=991 \
     GID=991 \


### PR DESCRIPTION
**Full Changelog**: https://github.com/Novik/ruTorrent/compare/v5.2.6...v5.2.8

# ruTorrent v5.2.8
This hotfix is recommended for common platforms. It increases the default file drop max size from 2MB to 5MB for larger torrent files.

## What's Changed
* Increase filedrop max file size to 5MB by stickz in https://github.com/Novik/ruTorrent/commit/2868f858c5a8e5ac960d48da35d17209824bddb4

# ruTorrent v5.2.7
This is a critical hotfix. It's highly recommended to upgrade. 
1. It fixes the search feature on mobile. (Thanks tohenk)

## What's Changed
* Don't hide top menu when resizing by tohenk in https://github.com/Novik/ruTorrent/pull/2945