### PR TITLE
ruTorrent: Upgrade to v5.2.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,7 +95,7 @@ LABEL description="rutorrent based on alpinelinux" \
 
 ARG FILEBOT=false
 ARG FILEBOT_VER=5.1.7
-ARG RUTORRENT_VER=5.2.8
+ARG RUTORRENT_VER=5.2.9
 
 ENV UID=991 \
     GID=991 \


### PR DESCRIPTION
# ruTorrent v5.2.9
This hotfix is recommended for common platforms. It resolves an error flooding issue with RSS when a 304 status code is sent.

## What's Changed
* fix(rss.php): http status 304 unmodified by SuperMiaw in https://github.com/Novik/ruTorrent/pull/2955

## New Contributors
* SuperMiaw made their first contribution in https://github.com/Novik/ruTorrent/pull/2955

**Full Changelog**: https://github.com/Novik/ruTorrent/compare/v5.2.8...v5.2.9