### PR TITLE
ruTorrent: Upgrade to v5.2.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,7 +95,7 @@ LABEL description="rutorrent based on alpinelinux" \
 
 ARG FILEBOT=false
 ARG FILEBOT_VER=5.1.7
-ARG RUTORRENT_VER=5.2.9
+ARG RUTORRENT_VER=5.2.10
 
 ENV UID=991 \
     GID=991 \


### PR DESCRIPTION
# ruTorrent v5.2.10
It is highly recommended for common platforms to upgrade. This hotfix resolves a performance regression in `v5.2` with dxSTable sorting. When running ten thousand torrents, there may be a significant slowdown without this hotfix.

## What's Changed
* Fix Chrome performance regression by anthonyryan1 in https://github.com/Novik/ruTorrent/pull/2960
* Refine pt-BR translation for country names by cantalupo555 in https://github.com/Novik/ruTorrent/pull/2961


**Full Changelog**: https://github.com/Novik/ruTorrent/compare/v5.2.9...v5.2.10