### PR TITLE
fix: install nginx from official repo to fix CVE-2026-42945 (CVSS 9.2 RCE)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -162,6 +162,10 @@ RUN echo "@314 http://dl-cdn.alpinelinux.org/alpine/v3.14/main" >> /etc/apk/repo
 RUN echo "@320 http://dl-cdn.alpinelinux.org/alpine/v3.20/main" >> /etc/apk/repositories \
   && apk --update --no-cache add s6@320
 
+RUN echo "@nginx https://packages.nginx.org/mainline/alpine/v3.21/main" >> /etc/apk/repositories \
+  && wget -qO /etc/apk/keys/nginx_signing.rsa.pub https://nginx.org/keys/nginx_signing.rsa.pub \
+  && apk --update --no-cache add nginx@nginx
+
 RUN apk --update --no-cache add \
     7zip \
     bash \
@@ -175,7 +179,6 @@ RUN apk --update --no-cache add \
     libzen-dev \
     mediainfo \
     ncurses \
-    nginx \
     openssl \
     php83 \
     php83-bcmath \


### PR DESCRIPTION
## What

Add the official nginx mainline Alpine package repository and install `nginx` from it instead of the Alpine 3.21 default repo.

```diff
+RUN echo "@nginx https://packages.nginx.org/mainline/alpine/v3.21/main" >> /etc/apk/repositories \
+  && wget -qO /etc/apk/keys/nginx_signing.rsa.pub https://nginx.org/keys/nginx_signing.rsa.pub \
+  && apk --update --no-cache add nginx@nginx
+
 RUN apk --update --no-cache add \
     7zip \
     ...
-    nginx \
```

## Why

Alpine 3.21 ships nginx 1.26.3 via its default apk repos, which is vulnerable to **CVE-2026-42945** (CVSS v4 **9.2 Critical**): a heap buffer overflow in `ngx_http_rewrite_module` allowing unauthenticated RCE on systems with ASLR disabled. A public PoC has been available since 2026-05-13.

The official nginx Alpine repository (packages.nginx.org) provides nginx **1.31.0** which includes the fix.

- **Affected:** nginx 0.6.27 – 1.30.0
- **Fixed in:** nginx 1.30.1, **1.31.0**
- **Advisory:** [nginx security advisories](https://nginx.org/en/security_advisories.html) · [F5 K000161019](https://my.f5.com/manage/s/article/K000161019) · [CVE-2026-42945](https://www.tenable.com/cve/CVE-2026-42945)